### PR TITLE
use python3 instead of python

### DIFF
--- a/engine-appliance/Makefile
+++ b/engine-appliance/Makefile
@@ -38,7 +38,7 @@ ovirt-engine-appliance.spec: VERSION_EXTRA=
 ovirt-engine-appliance.spec: RELEASE=$(shell date +%Y%m%d%H%M%S).1
 ovirt-engine-appliance.spec: OVAFILENAME=ovirt-engine-appliance.ova
 
-PYTHON ?= PYTHONPATH="$(PWD)/imagefactory/" python
+PYTHON ?= PYTHONPATH="$(PWD)/imagefactory/" python3
 
 # Direct for virt-sparsify: http://libguestfs.org/guestfs.3.html#backend
 export LIBGUESTFS_BACKEND=direct

--- a/engine-appliance/scripts/create_ova.py
+++ b/engine-appliance/scripts/create_ova.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 
 from imagefactory_plugins.ovfcommon.ovfcommon import RHEVOVFPackage


### PR DESCRIPTION
"python" should never be used anymore

Change-Id: I8f81d6952f6d0046c8e7bc02775896aaf9f8601b
Signed-off-by: Michal Skrivanek <michal.skrivanek@redhat.com>

## Changes introduced with this PR

* We should use Python with a specific version, i.e. python3

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]