### PR TITLE
packaging: include manifest within RPM

### DIFF
--- a/engine-appliance/Makefile
+++ b/engine-appliance/Makefile
@@ -85,7 +85,7 @@ ovirt-engine-appliance.spec: data/ovirt-engine-appliance.spec.in
 
 RPMBUILD = rpmbuild
 TMPREPOS = tmp.repos
-rpm srpm:   ovirt-engine-appliance.spec ovirt-engine-appliance.ova
+rpm srpm:   ovirt-engine-appliance.spec ovirt-engine-appliance.ova ovirt-engine-appliance-manifest-rpm
 	rm -fr "$(TMPREPOS)"
 	mkdir -p $(TMPREPOS)/{SPECS,RPMS,SRPMS,SOURCES}
 	$(RPMBUILD) --define="_topdir `pwd`/$(TMPREPOS)" --define "_sourcedir `pwd`" -ba $<

--- a/engine-appliance/data/ovirt-engine-appliance.spec.in
+++ b/engine-appliance/data/ovirt-engine-appliance.spec.in
@@ -10,6 +10,7 @@ Summary:    The oVirt Engine Appliance image (OVA)
 Group:      Applications/System
 URL:        https://www.ovirt.org/
 Source0:    @OVAFILENAME@
+Source1:    ovirt-engine-appliance-manifest-rpm
 BuildArch:  x86_64
 
 BuildRequires: grep
@@ -26,6 +27,7 @@ This package contains the prebuild oVirt Engine appliance image. It is intended 
 be used with hosted-engine setup.
 
 %prep
+cp %{SOURCE1} .
 
 %build
 
@@ -50,6 +52,7 @@ rm -rf %{buildroot}
 %files
 %{_appliance_dir}
 %{_he_discovery_file}
+%doc ovirt-engine-appliance-manifest-rpm
 
 %changelog
 * Wed Feb 02 2022 Lev Veyde <lveyde@redhat.com> - 4.4


### PR DESCRIPTION
    packaging: include manifest within RPM
    
    Adding generated manifest within the appliance RPM
    
    Change-Id: I5a3a2356ee2c4ec7423c6e6941ffe762c1df4da1
    Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=2000066
    Signed-off-by: Sandro Bonazzola <sbonazzo@redhat.com>

## Changes introduced with this PR

* Backported the Adding generated manifest within the appliance RPM ovirt-4.4 branch

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]