### PR TITLE
github: Added cleanup step to the beginning

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,10 @@ jobs:
       options: --privileged
 
     steps:
+    - name: Clean up entire workdir
+      if: ${{ !inputs.keep_workdir }}
+      run: rm -rf $PWD/*
+
     - name: fix loop mounts
       run: for i in `seq 0 9`; do [[ ! -b /dev/loop$i ]] && mknod /dev/loop$i -m0660 b 7 $i; done
 


### PR DESCRIPTION
The build may fail, and in that case the system may become out of
diskspace on the next run, due to leftovers from the failed run.

Signed-off-by: Lev Veyde <lveyde@redhat.com>

## Changes introduced with this PR

* always perform a cleanup before running the build

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]