### PR TITLE
Really fail on any failed %post command

### DIFF
--- a/engine-appliance/data/ovirt-engine-appliance.j2
+++ b/engine-appliance/data/ovirt-engine-appliance.j2
@@ -123,7 +123,7 @@ mod_session
 # Adding upstream oVirt
 #
 %post --erroronfail
-set -x
+set -xe
 # For build issues debugging purpose, looking for known repositories
 dnf repolist
 


### PR DESCRIPTION
We included --erroronfail, but it seems to be not enough in case
of bash, since it jumps over any failed commands, thus it will
only fail if the last command in the block fails.

This is not the behaviour that we want, as we want to fail the
installation if any of the steps fail.

Signed-off-by: Lev Veyde <lveyde@redhat.com>

## Changes introduced with this PR

* The kickstart template was modified, so we'll fail the installation if something goes wrong.
* This is really important to help prevent from broken images to slip through.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]