### PR TITLE
Don't use ipv6 during build

### DIFF
--- a/engine-appliance/data/ovirt-engine-appliance.j2
+++ b/engine-appliance/data/ovirt-engine-appliance.j2
@@ -15,7 +15,7 @@ bootloader --timeout=1 --append="console=tty1 console=ttyS0,115200n8"
 authselect select minimal
 selinux --enforcing
 firewall --enabled --service={{ data["firewall"] }}
-network
+network --noipv6
 services --enabled={{ data["services"] }}
 rootpw --lock
 


### PR DESCRIPTION
## Changes introduced with this PR

For some reason, the build get stuck when ipv6 is used.
The logs are reporting:

```
16:04:06,579 DEBUG NetworkManager:<debug> [1646841846.5790] platform: (ens3) signal: address 6 changed: fec0::5054:ff:fe12:3456/64 lft 86401sec pref 14401sec lifetime 8668-8668[14401,86401] dev 2 flags noprefixroute src kernel
```

Disabling it.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y/n] yes