### PR TITLE
ks: skip baseurl setting

### DIFF
--- a/engine-appliance/data/ovirt-engine-appliance.j2
+++ b/engine-appliance/data/ovirt-engine-appliance.j2
@@ -134,9 +134,6 @@ dnf config-manager --set-enabled ovirt-45-upstream-testing
 
 dnf -y update
 
-# Use baseurl instead of repo to ensure we use the latest rpms
-sed -i "s/^mirrorlist/#mirrorlist/ ; s/^#baseurl/baseurl/" $(find /etc/yum.repos.d/ovirt*.repo -type f ! -name "*dep*")
-
 dnf module enable -y javapackages-tools pki-deps 389-ds postgresql:12 mod_auth_openidc
 
 dnf install -y \


### PR DESCRIPTION
## Changes introduced with this PR

* in 4.5 we are using centos mirrors, can't rely on baseurl.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y/n] yes