### PR TITLE
don't require ovirt-engine-extension-logger-log4j

### DIFF
--- a/engine-appliance/data/ovirt-engine-appliance.j2
+++ b/engine-appliance/data/ovirt-engine-appliance.j2
@@ -152,10 +152,6 @@ dnf install -y \
 dnf install -y \
 	ovirt-engine-extension-aaa-misc
 
-# Additional package that we recommend for more flexible engine logging
-dnf install -y \
-	ovirt-engine-extension-logger-log4j
-
 #
 echo "Creating a partial answer file"
 #


### PR DESCRIPTION
## Changes introduced with this PR

* ovirt-engine-extension-logger-log4j has been dropped in 4.4.10. Dropping it.


## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y/n] y