### PR TITLE
Move space to /var/tmp from /var and not from /tmp

### DIFF
--- a/engine-appliance/data/ovirt-engine-appliance.j2
+++ b/engine-appliance/data/ovirt-engine-appliance.j2
@@ -31,9 +31,9 @@ volgroup ovirt --pesize=4096 pv.01
 
 logvol / --fstype=xfs --name=root --vgname=ovirt --size=6144 --grow
 logvol /home --fstype=xfs --name=home --vgname=ovirt --size=1024 --fsoptions="nodev"
-logvol /tmp --fstype=xfs --name=tmp --vgname=ovirt --size=1024 --fsoptions="nodev,noexec,nosuid"
-logvol /var --fstype=xfs --name=var --vgname=ovirt --size=20480 --fsoptions="nodev"
-logvol /var/tmp --fstype=xfs --name=vartmp --vgname=ovirt --size=1024 --fsoptions="nodev,noexec,nosuid"
+logvol /tmp --fstype=xfs --name=tmp --vgname=ovirt --size=2048 --fsoptions="nodev,noexec,nosuid"
+logvol /var --fstype=xfs --name=var --vgname=ovirt --size=18432 --fsoptions="nodev"
+logvol /var/tmp --fstype=xfs --name=vartmp --vgname=ovirt --size=2048 --fsoptions="nodev,noexec,nosuid"
 logvol /var/log --fstype=xfs --name=log --vgname=ovirt --size=10240 --fsoptions="nodev"
 logvol /var/log/audit --fstype=xfs --name=audit --vgname=ovirt --size=1024 --fsoptions="nodev"
 logvol swap --name=swap --vgname=ovirt --size=8192


### PR DESCRIPTION
Can't be sure, but IMO it's possible that people did things on the
engine that used more than 1GB on /tmp, and reducing it from 2GB to 1GB
will break their use.

Change-Id: I17ecbcbe976f908755a3ce06a85344db9b39b51c
Signed-off-by: Yedidyah Bar David <didi@redhat.com>

Fixes issue # (delete if not relevant)

## Changes introduced with this PR

*

*

*

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y/n]