### PR TITLE
build: debug guestfish crashes

### DIFF
--- a/engine-appliance/Makefile
+++ b/engine-appliance/Makefile
@@ -44,6 +44,9 @@ PYTHON ?= python3
 export LIBGUESTFS_BACKEND=direct
 # Workaround nest problem: https://bugzilla.redhat.com/show_bug.cgi?id=1195278
 export LIBGUESTFS_BACKEND_SETTINGS=force_tcg
+# Debugging issues when guestfish crashes
+export LIBGUESTFS_DEBUG=1
+export LIBGUESTFS_TRACE=1
 export TMPDIR=/var/tmp/
 export TEST_ENGINE_ROOTFS_IMG=$(PWD)/ovirt-engine-appliance.qcow2
 


### PR DESCRIPTION
## Changes introduced with this PR

* Debugging build crashes as in https://github.com/oVirt/ovirt-appliance/runs/6418362603?check_suite_focus=true#step:6:6


## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y/n] y