### PR TITLE
add cs9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,9 +26,11 @@ jobs:
           - name: el8
             container-name: el8stream
             base-distro: centos-stream-8
+            boot-iso-url: http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/images/boot.iso
           - name: el9
             container-name: el9stream
             base-distro: centos-stream-9
+            boot-iso-url: http://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/images/boot.iso
     name: build-${{ matrix.name }}
     runs-on: [image-builders, "${{ matrix.name }}"]
     container:
@@ -46,7 +48,7 @@ jobs:
       - name: Build the OVA
         run: |
           cd engine-appliance
-          make DISTRO=${{ matrix.base-distro }} &
+          make DISTRO=${{ matrix.base-distro }} BOOTISOURL=${{ matrix.boot-iso-url }} &
           tail --pid=$! --retry -f virt-install.log ||:
 
       - name: Check OVA content

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,10 +25,10 @@ jobs:
         include:
           - name: el8
             container-name: el8stream
-            base-distro: centos
+            base-distro: centos-stream-8
           - name: el9
             container-name: el9stream
-            base-distro: centos
+            base-distro: centos-stream-9
     name: build-${{ matrix.name }}
     runs-on: [image-builders, "${{ matrix.name }}"]
     container:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,8 +25,10 @@ jobs:
         include:
           - name: el8
             container-name: el8stream
+            base-distro: centos
           - name: el9
             container-name: el9stream
+            base-distro: centos
     name: build-${{ matrix.name }}
     runs-on: [image-builders, "${{ matrix.name }}"]
     container:
@@ -44,7 +46,7 @@ jobs:
       - name: Build the OVA
         run: |
           cd engine-appliance
-          make &
+          make DISTRO=${{ matrix.base-distro }} &
           tail --pid=$! --retry -f virt-install.log ||:
 
       - name: Check OVA content

--- a/engine-appliance/Makefile
+++ b/engine-appliance/Makefile
@@ -20,8 +20,7 @@ OVA_CPUS ?= 4
 
 ARCH=x86_64
 DISTRO=default_distro
-RELEASEVER=8-stream
-BOOTISOURL=http://mirror.centos.org/centos/$(RELEASEVER)/BaseOS/$(ARCH)/os/images/boot.iso
+BOOTISOURL=http://some.host/some/path/boot.iso
 CURLOPTS=-L
 
 

--- a/engine-appliance/Makefile
+++ b/engine-appliance/Makefile
@@ -32,7 +32,6 @@ LMC_CPUS ?= 4
 #
 # oVirt specific vars
 #
-OVIRTRELEASERPM=ovirt-release-master
 ovirt-engine-appliance.spec: VERSION=4.5
 ovirt-engine-appliance.spec: VERSION_EXTRA=
 ovirt-engine-appliance.spec: RELEASE=$(shell date +%Y%m%d%H%M%S).1
@@ -60,7 +59,7 @@ boot.iso:
 	curl $(CURLOPTS) -O $(BOOTISOURL)
 
 %.ks: data/%.j2
-	scripts/renderks.py $(OVIRTRELEASERPM) $(DISTRO) > "$@"
+	scripts/renderks.py $(DISTRO) > "$@"
 
 %.qcow2: SPARSE=1
 %.qcow2: %.ks boot.iso

--- a/engine-appliance/Makefile
+++ b/engine-appliance/Makefile
@@ -19,7 +19,7 @@ OVA_RAM ?= 16384
 OVA_CPUS ?= 4
 
 ARCH=x86_64
-DISTRO=centos
+DISTRO=default_distro
 RELEASEVER=8-stream
 BOOTISOURL=http://mirror.centos.org/centos/$(RELEASEVER)/BaseOS/$(ARCH)/os/images/boot.iso
 CURLOPTS=-L

--- a/engine-appliance/data/distro-defs.yml
+++ b/engine-appliance/data/distro-defs.yml
@@ -1,5 +1,5 @@
 ---
-centos:
+centos-stream-8:
   url: --mirrorlist=http://mirrorlist.centos.org/?repo=baseos&release=8-stream&arch=$basearch
   repos:
     extra: --mirrorlist=http://mirrorlist.centos.org/?repo=extras&release=8-stream&arch=$basearch
@@ -12,3 +12,16 @@ centos:
     - centos-stream-repos
   ovirtreleaserpm: ovirt-release-master
   ovirtreleaserpmrepo: https://download.copr.fedorainfracloud.org/results/ovirt/ovirt-master-snapshot/centos-stream-8-x86_64/
+
+centos-stream-9:
+  url: --metalink=https://mirrors.centos.org/metalink?repo=centos-baseos-9-stream&arch=$basearch&protocol=https,http
+  repos:
+    extra: --metalink=https://mirrors.centos.org/metalink?repo=centos-extras-sig-extras-common-9-stream&arch=$basearch&protocol=https,http
+    appstream: --metalink=https://mirrors.centos.org/metalink?repo=centos-appstream-9-stream&arch=$basearch&protocol=https,http
+  services: sshd
+  firewall: cockpit
+  packages:
+    - python3
+    - centos-stream-repos
+  ovirtreleaserpm: ovirt-release-master
+  ovirtreleaserpmrepo: https://download.copr.fedorainfracloud.org/results/ovirt/ovirt-master-snapshot/centos-stream-9-x86_64/

--- a/engine-appliance/data/distro-defs.yml
+++ b/engine-appliance/data/distro-defs.yml
@@ -10,3 +10,4 @@ centos:
   packages:
     - python36
     - centos-stream-repos
+  ovirtreleaserpm: ovirt-release-master

--- a/engine-appliance/data/distro-defs.yml
+++ b/engine-appliance/data/distro-defs.yml
@@ -11,3 +11,4 @@ centos:
     - python36
     - centos-stream-repos
   ovirtreleaserpm: ovirt-release-master
+  ovirtreleaserpmrepo: https://download.copr.fedorainfracloud.org/results/ovirt/ovirt-master-snapshot/centos-stream-8-x86_64/

--- a/engine-appliance/data/ovirt-engine-appliance.j2
+++ b/engine-appliance/data/ovirt-engine-appliance.j2
@@ -135,7 +135,7 @@ dnf repolist
 
 
 rpm --import https://download.copr.fedorainfracloud.org/results/ovirt/ovirt-master-snapshot/pubkey.gpg
-dnf --repofrompath=ovirt-master-snapshot,https://download.copr.fedorainfracloud.org/results/ovirt/ovirt-master-snapshot/centos-stream-8-x86_64/ install -y {{ releaserpm }}
+dnf --repofrompath=ovirt-master-snapshot,https://download.copr.fedorainfracloud.org/results/ovirt/ovirt-master-snapshot/centos-stream-8-x86_64/ install -y {{ data["ovirtreleaserpm"] }}
 dnf config-manager --set-enabled powertools || true
 
 dnf -y update

--- a/engine-appliance/data/ovirt-engine-appliance.j2
+++ b/engine-appliance/data/ovirt-engine-appliance.j2
@@ -135,7 +135,7 @@ dnf repolist
 
 
 rpm --import https://download.copr.fedorainfracloud.org/results/ovirt/ovirt-master-snapshot/pubkey.gpg
-dnf --repofrompath=ovirt-master-snapshot,https://download.copr.fedorainfracloud.org/results/ovirt/ovirt-master-snapshot/centos-stream-8-x86_64/ install -y {{ data["ovirtreleaserpm"] }}
+dnf --repofrompath=ovirt-release-repo,{{ data["ovirtreleaserpmrepo"] }} install -y {{ data["ovirtreleaserpm"] }}
 dnf config-manager --set-enabled powertools || true
 
 dnf -y update

--- a/engine-appliance/data/ovirt-engine-appliance.j2
+++ b/engine-appliance/data/ovirt-engine-appliance.j2
@@ -73,9 +73,8 @@ qemu-guest-agent
 #cloud-utils
 
 cloud-utils-growpart
-# We need this image to be portable; also, rescue mode isn't useful here.
+# We need this image to be portable
 dracut-config-generic
-dracut-norescue
 
 # Needed by oVirt
 firewalld

--- a/engine-appliance/data/ovirt-engine-appliance.j2
+++ b/engine-appliance/data/ovirt-engine-appliance.j2
@@ -142,7 +142,8 @@ dnf -y update
 # Use baseurl instead of repo to ensure we use the latest rpms
 sed -i "s/^mirrorlist/#mirrorlist/ ; s/^#baseurl/baseurl/" $(find /etc/yum.repos.d/ovirt*.repo -type f ! -name "*dep*")
 
-dnf module enable -y javapackages-tools pki-deps 389-ds postgresql:12 mod_auth_openidc nodejs:14
+# All of this does not seem to be needed on CentOS Stream 9, but fails there. For now, just don't fail.
+dnf module enable -y javapackages-tools pki-deps 389-ds postgresql:12 mod_auth_openidc nodejs:14 || true
 
 dnf install -y \
 	ovirt-engine \

--- a/engine-appliance/scripts/renderks.py
+++ b/engine-appliance/scripts/renderks.py
@@ -10,7 +10,6 @@ def main():
     parser = argparse.ArgumentParser(prog="renderks")
     parser.add_argument("--data-dir", default="./data",
                         help="jinja2 environment directory")
-    parser.add_argument("RELEASERPM", help="release-rpm url")
     parser.add_argument("DISTRO", help="distro name")
     args = parser.parse_args()
 
@@ -19,7 +18,7 @@ def main():
 
     env = Environment(loader=FileSystemLoader(searchpath=args.data_dir))
     template = env.get_template("ovirt-engine-appliance.j2")
-    print(template.render(data=data, releaserpm=args.RELEASERPM))
+    print(template.render(data=data))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- add el8 and el9 matrix builds (#24)
- auth is deprecated and replaced by authselect (#26)
- Really fail on any failed %post command
- automation: build daily and report issues
- fix release rpm installation
- Don't use ipv6 during build
- Check OVA content
- automation: separate manifest for el8 and el9
- build: add missing directory change
- automation: allow to create issues
- appliance: enable nodejs:14 module
- don't require ovirt-engine-extension-logger-log4j (#43)
- Make the appliance DISA STIG complaint (#46)
- Fix the name of /var/tmp volume (#48)
- Move space to /var/tmp from /var and not from /tmp (#49)
- github: add job timeout (#51)
- Disable keycloak (#52)
- Fix for Disable keycloak (#53)
- Fix for disabling keycloak as default sso provider (#54)
- keycloak disablement no longer needed
- build: debug guestfish crashes
- Disable cloud-init networking
- Change Bugzilla link to GitHub issues
- Move releaserpm to distro-defs
- Make ovirt-release rpm repo parametric
- github: Pass distro
- Build also basing on CentOS Stream 9
- Make Boot ISO URL parametric
- Do not install dracut-norescue
- Do not fail if enabling dnf modules fails

Fixes issue # (delete if not relevant)

## Changes introduced with this PR

*

*

*

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y/n]