### PR TITLE
Explicitly install lvm2

### DIFF
--- a/engine-appliance/data/ovirt-engine-appliance.j2
+++ b/engine-appliance/data/ovirt-engine-appliance.j2
@@ -52,6 +52,7 @@ grub2-pc
 # oVirt is not using EFI
 #grub2-efi-x64
 #shim
+lvm2
 
 # pull firmware packages out
 -a*firmware*

--- a/engine-appliance/data/ovirt-engine-appliance.j2
+++ b/engine-appliance/data/ovirt-engine-appliance.j2
@@ -137,7 +137,9 @@ rpm --import https://download.copr.fedorainfracloud.org/results/ovirt/ovirt-mast
 dnf --repofrompath=ovirt-release-repo,{{ data["ovirtreleaserpmrepo"] }} install -y {{ data["ovirtreleaserpm"] }}
 dnf config-manager --set-enabled powertools || true
 
-dnf -y update
+# Adding --nobest, hopefully temporarily, because current usbguard needs protobuf-3.14, while ovirt-master-centos-stream-ceph-pacific-testing has 3.19.
+# TODO Remove '--nobest' once this is resolved somehow (probably by CentOS upgrading their protobuf and rebuilding usbguard)
+dnf -y update --nobest
 
 # Use baseurl instead of repo to ensure we use the latest rpms
 find /etc/yum.repos.d -type f -name "ovirt*.repo" ! -name "*dep*" -exec sed -i "s/^mirrorlist/#mirrorlist/ ; s/^#baseurl/baseurl/" {} \;


### PR DESCRIPTION
It used to be included via dependencies, but apparently does not anymore, in current CentOS Stream 9. So install it directly. Without this, boot fails, getting stuck, due to failure in mounting /var.

Change-Id: I18800c3edbd47bffcac9479f6230a5f251bcac66
Signed-off-by: Yedidyah Bar David <didi@redhat.com>

Fixes issue # (delete if not relevant)

## Changes introduced with this PR

*

*

*

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y/n]