### PR TITLE
dnf update --nobest

### DIFF
--- a/engine-appliance/data/ovirt-engine-appliance.j2
+++ b/engine-appliance/data/ovirt-engine-appliance.j2
@@ -137,7 +137,9 @@ rpm --import https://download.copr.fedorainfracloud.org/results/ovirt/ovirt-mast
 dnf --repofrompath=ovirt-release-repo,{{ data["ovirtreleaserpmrepo"] }} install -y {{ data["ovirtreleaserpm"] }}
 dnf config-manager --set-enabled powertools || true
 
-dnf -y update
+# Adding --nobest, hopefully temporarily, because current usbguard needs protobuf-3.14, while ovirt-master-centos-stream-ceph-pacific-testing has 3.19.
+# TODO Remove '--nobest' once this is resolved somehow (probably by CentOS upgrading their protobuf and rebuilding usbguard)
+dnf -y update --nobest
 
 # Use baseurl instead of repo to ensure we use the latest rpms
 find /etc/yum.repos.d -type f -name "ovirt*.repo" ! -name "*dep*" -exec sed -i "s/^mirrorlist/#mirrorlist/ ; s/^#baseurl/baseurl/" {} \;


### PR DESCRIPTION
Add --nobest, hopefully temporarily, because current usbguard needs protobuf-3.14, while ovirt-master-centos-stream-ceph-pacific-testing has 3.19.

This should be reverted once usbguard is rebuilt with the updated protobuf.

Change-Id: I109ea87164e1cc8ce0be59bb363e498da45fd55e
Signed-off-by: Yedidyah Bar David <didi@redhat.com>

Fixes issue # (delete if not relevant)

## Changes introduced with this PR

*

*

*

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y/n]