### PR TITLE
Remove lvmdevices

### DIFF
--- a/engine-appliance/data/ovirt-engine-appliance.j2
+++ b/engine-appliance/data/ovirt-engine-appliance.j2
@@ -193,4 +193,7 @@ systemctl enable qemu-guest-agent
 
 rm -vf /etc/sysconfig/network-scripts/ifcfg-e*
 
+# Remove lvmdevices, in case it was created by anaconda - target VM will likely have different devices
+rm -vf /etc/lvm/devices/system.devices
+
 %end


### PR DESCRIPTION
Remove lvmdevices, in case it was created by anaconda - target VM will likely have different devices, thus boot will fail. See also:

https://github.com/rhinstaller/anaconda/commit/9cccada8

Change-Id: I3956e9c87e4df18064cb9beff3f4e435ade569c8
Signed-off-by: Yedidyah Bar David <didi@redhat.com>

Fixes issue # (delete if not relevant)

## Changes introduced with this PR

*

*

*

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y/n]