### PR TITLE
Drop libguestfs backend config at build time

### DIFF
--- a/engine-appliance/Makefile
+++ b/engine-appliance/Makefile
@@ -42,9 +42,11 @@ ovirt-engine-appliance.spec: OVAFILENAME=ovirt-engine-appliance.ova
 PYTHON ?= python3
 
 # Direct for virt-sparsify: http://libguestfs.org/guestfs.3.html#backend
-export LIBGUESTFS_BACKEND=direct
+# direct causes libguestfs to use a deprecated machine type for qemu
+# export LIBGUESTFS_BACKEND=direct
 # Workaround nest problem: https://bugzilla.redhat.com/show_bug.cgi?id=1195278
-export LIBGUESTFS_BACKEND_SETTINGS=force_tcg
+# force_tcg causes corruption of the manifest while running guestfish
+#export LIBGUESTFS_BACKEND_SETTINGS=force_tcg
 # Debugging issues when guestfish crashes
 export LIBGUESTFS_DEBUG=1
 export LIBGUESTFS_TRACE=1


### PR DESCRIPTION
## Changes introduced with this PR

Commenting libguestfs backend configuration workarounds as they seems not needed anymore and actually causing troubles.

See comments in the Makefile for more details.

Signed-off-by: Sandro Bonazzola <sbonazzo@redhat.com>

## Are you the owner of the code you are sending in, or do you have permission of the owner?

y