### PR TITLE
Revert "Drop libguestfs backend config at build time"

### DIFF
--- a/engine-appliance/Makefile
+++ b/engine-appliance/Makefile
@@ -42,11 +42,9 @@ ovirt-engine-appliance.spec: OVAFILENAME=ovirt-engine-appliance.ova
 PYTHON ?= python3
 
 # Direct for virt-sparsify: http://libguestfs.org/guestfs.3.html#backend
-# direct causes libguestfs to use a deprecated machine type for qemu
-# export LIBGUESTFS_BACKEND=direct
+export LIBGUESTFS_BACKEND=direct
 # Workaround nest problem: https://bugzilla.redhat.com/show_bug.cgi?id=1195278
-# force_tcg causes corruption of the manifest while running guestfish
-#export LIBGUESTFS_BACKEND_SETTINGS=force_tcg
+export LIBGUESTFS_BACKEND_SETTINGS=force_tcg
 # Debugging issues when guestfish crashes
 export LIBGUESTFS_DEBUG=1
 export LIBGUESTFS_TRACE=1


### PR DESCRIPTION
This reverts commit 5f404a5556c30589b63cd480bb4e6bfaa430ca95.

Since we don't have running libvirt inside the container, using libvirt backend is not an option for us.

## Changes introduced with this PR

* Revert the removal of the direct backend usage

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]