### PR TITLE
Updated build.yml - increased job timeout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ on:
 
 jobs:
   build-matrix:
-    timeout-minutes: 60
+    timeout-minutes: 80
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Increased timeout to 80 minutes.

It seems that in some frequent cases 60 minutes is not enough time to finish the build, causing it to fail.

Thus I'm increasing it by 20 minutes, which hopefully will be enough.


## Changes introduced with this PR

* Increased the job timeout by 20 minutes, to 80 minutes total.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]